### PR TITLE
fix: symloop perf

### DIFF
--- a/src/async.js
+++ b/src/async.js
@@ -6,22 +6,22 @@ const real = promisify(realpath);
 const toStats = promisify(lstat);
 const list = promisify(readdir);
 
-export async function totalist(dir, callback, prefix, cache) {
-	cache = cache || new Set;
-	dir = await real(resolve('.', dir));
-	if (cache.has(dir)) return;
-
-	cache.add(dir);
-	await list(dir).then(arr => {
-		return Promise.all(
+async function walk(dir, stats, callback, cache, prefix) {
+	if (!stats.isSymbolicLink() || !cache.has(dir = await real(dir))) {
+		cache.add(dir) && await list(dir).then(arr => Promise.all(
 			arr.map(str => {
 				let abs = join(dir, str);
-				return toStats(abs).then(stats => {
-					return stats.isDirectory()
-						? totalist(abs, callback, join(prefix || '', str), cache)
-						: callback(join(prefix || '', str), abs, stats)
+				return toStats(abs).then(xyz => {
+					return xyz.isDirectory()
+						? walk(abs, xyz, callback, cache, join(prefix, str))
+						: callback(join(prefix, str), abs, xyz)
 				});
 			})
-		);
-	});
+		));
+	}
+}
+
+export async function totalist(dir, callback, prefix) {
+	let stats = await toStats(dir = resolve('.', dir));
+	if (stats.isDirectory()) await walk(dir, stats, callback, new Set, prefix || '');
 }

--- a/src/sync.d.ts
+++ b/src/sync.d.ts
@@ -1,3 +1,3 @@
 import { Stats } from 'fs';
 export type Caller = (relPath: string, absPath: string, stats: Stats) => any;
-export function totalist(dir: string, callback: Caller, prefix?: string, cache?: Set<string>): void;
+export function totalist(dir: string, callback: Caller, prefix?: string): void;


### PR DESCRIPTION
* Tests are back down to 5ms now (down from 10-11ms)
* Uses `realpath` only for symlinks (expensive)
* Passes realpath value around once followed
* Uses realpath value for cache check

Unrelated fix:
* Will not throw error on file input